### PR TITLE
Tests that are testing nothing?

### DIFF
--- a/test/test_chipyard_dockerfile_bar.py
+++ b/test/test_chipyard_dockerfile_bar.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DOCKERFILE = REPO_ROOT / "dockerfiles" / "ChipyardDockerfileBAR"
+DOCKERFILE = REPO_ROOT / "dockerfiles" / "ChipyardDockerfileBAR" # this tests a file that doesn't exist. All 3 tests read dockerfiles/ChipyardDockerfileBAR, which isn't in the repo (and never was — the public history is a single squashed commit)
 
 
 def test_bar_dockerfile_patches_chipyard_glibc_rewrite():

--- a/test/test_metrics_logger.py
+++ b/test/test_metrics_logger.py
@@ -55,6 +55,7 @@ def test_tensorboard_backend():
         files = os.listdir(tmpdir)
         assert any("events.out.tfevents" in f for f in files), f"No event files in {files}"
 
+# can skip the tests, deps not defined.
 
 def test_from_config_does_not_mutate_input():
     cfg = {"backend": "none", "extra": "value"}


### PR DESCRIPTION
Hi UC Berkeley,

When looking for dirs, I came across `test/test_chipyard_dockerfile_bar.py`, this obviously holds a garden variety of test files, but some of the instruction in the those files say to test files that doesn't exist. 

All 3 tests read `dockerfiles/ChipyardDockerfileBAR`, which isn't in the repo (and never was , the public history is a single squashed commit). FileNotFoundError, always red. So for example: 

```python
DOCKERFILE = Path(__file__).resolve().parents[1] / "dockerfiles" / "ChipyardDockerfileBAR"
```
That file does not exist in the repository. The `dockerfiles/` directory contains `ChipyardDockerfile`, `ChiaDockerfile`, `VerilatorRunDockerfile`, etc., but no `ChipyardDockerfileBAR` variant. 

Since the public history is a single squashed commit, the file was never present in this repo ,  it was presumably lost (or intentionally excluded as site-specific) when the internal tree was exported.

It's easy to reproduce: 

```
$ pip install -e . && python -m pytest test/test_chipyard_dockerfile_bar.py
FileNotFoundError: [Errno 2] No such file or directory:
  '.../dockerfiles/ChipyardDockerfileBAR'
```

Failing tests (deterministic, environment-independent):
- `test_bar_dockerfile_patches_chipyard_glibc_rewrite`
- `test_bar_dockerfile_clones_aws_fpga_firesim_f2`
- `test_bar_dockerfile_does_not_pin_chipyard_ref`

The suite is red at HEAD on any fresh clone. Because `dockerfiles/ChipyardDockerfileBAR` is the only reference to that filename anywhere in the tree, the assertions (glibc-rewrite patching, `aws-fpga` F2 platform cloning, unpinned Chipyard ref) are asserting properties of an artifact the repo cannot produce.

## My suggestion

1. Restore `ChipyardDockerfileBAR` from the internal tree if it was meant to ship.
2. If it's site-specific (the `BAR` suffix suggests a Berkeley-internal image), delete the test module, or
3. Guard collection with `pytest.mark.skipif(not DOCKERFILE.exists(), ...)` so external checkouts skip rather than fail though a skip that can never un-skip publicly is arguably worse than deletion.
