### PR TITLE
Add skip condition for tests in test_metrics_logger

### DIFF
--- a/test/test_metrics_logger.py
+++ b/test/test_metrics_logger.py
@@ -7,6 +7,7 @@ import tempfile
 
 from chia.trace.metrics import MetricsLogger, NullBackend, TensorBoardBackend
 
+# skip the tests when the optional dep is absent. One line at the top of each affected test.
 
 def test_null_backend():
     m = MetricsLogger(backend="none")


### PR DESCRIPTION
Hey UC Berkeley,

So you should skip the tests when the optional dep is absent. One line at the top of each affected test:
```pyton3
pythondef test_tensorboard_backend():
pytest.importorskip("tensorboardX")
with tempfile.TemporaryDirectory() as tmpdir
```

```python3
def test_tensorboard_demo():
pytest.importorskip("tensorboardX")
m = MetricsLogger.from_config({"backend": "tensorboard", "log_dir": TB_DEMO_DIR})
```
Plus you should import pytest at the top of the file.

Now a default install reports these as skipped instead of failed, and they run normally whenever tensorboardX is present. 

That matches how the rest of the repo already treats optional infra, the live EC2/GCP tests skip rather than fail.

One wrinkle specific to this file: it has an `if __name__ == "__main__"`: block that calls the tests directly as a script. 

`pytest.importorskip` raises a Skipped exception outside a pytest run, so if that manual runner matters, a marker based on `find_spec` is more robust for both modes:

```python3
pythonimport importlib.util
import pytest
```
Then:

`HAS_TBX = importlib.util.find_spec("tensorboardX")` is not None.

```python3
@pytest.mark.skipif(not HAS_TBX, reason="tensorboardX not installed (pip install chia[tensorboard])")
def test_tensorboard_backend():
```
The guard the two calls in the` __main__` block with if HAS_TBX.

Cheers,
Michael