### PR TITLE
[riscv_extensions]: Adds --prebuilt-stress flag to run the stress pha…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "examples/benchmarks"]
 	path = examples/benchmarks
 	url = https://github.com/ucb-bar/chia_benchmarks.git
+[submodule "examples/riscv_extensions/prebuilt_stress"]
+	path = examples/riscv_extensions/prebuilt_stress
+	url = https://github.com/ucb-bar/chia-riscv-extensions-prebuilt.git

--- a/examples/riscv_extensions/multi_loop.py
+++ b/examples/riscv_extensions/multi_loop.py
@@ -78,7 +78,8 @@ def _render_ppa(results) -> str:
     return "".join(out)
 
 
-def _run_one(ext_name: str, ts: str, seed_diff: str | None = None, synth: bool = True):
+def _run_one(ext_name: str, ts: str, seed_diff: str | None = None, synth: bool = True,
+             prebuilt: bool = False):
     """One extension: claim a sweep, snapshot src, run the inner loop, then archive
     whatever exists. Best-effort and self-contained: a crash — or nodes that never
     produced anything (missing/empty work_root, DB down) — yields (None, sweep_path)
@@ -93,7 +94,8 @@ def _run_one(ext_name: str, ts: str, seed_diff: str | None = None, synth: bool =
         sweep_n, sweep_path = get(db_node.claim_sweep.chia_remote(ext_name))
         get(db_node.archive_dir.chia_remote(sweep_path, "src", _tar_dir(_VEXT_DIR), extension=ext_name))
         result = run_vext_loop(ext, run_id, work_root,
-                               seed_diff=seed_diff, archive_dir=sweep_path, synth=synth)
+                               seed_diff=seed_diff, archive_dir=sweep_path, synth=synth,
+                               prebuilt=prebuilt)
     except Exception:
         import traceback
         print(f"[{ext_name}] pipeline FAILED:\n{traceback.format_exc()}", flush=True)
@@ -119,6 +121,9 @@ def _parse_args():
                         "meant for single-extension runs)")
     p.add_argument("--no-synth", action="store_true",
                    help="skip sky130 PPA synthesis (run on a cluster with no synth node)")
+    p.add_argument("--prebuilt-stress", action="store_true",
+                   help="seed the stress pool from committed prebuilt binaries instead of "
+                        "generating with riscv-dv (run on a cluster with no Xcelium license)")
     return p.parse_args()
 
 
@@ -135,7 +140,8 @@ def main() -> int:
     seed = open(args.seed_diff).read() if args.seed_diff else None
     n = min(MAX_PARALLEL_PIPELINES, len(args.extensions))
     with ThreadPoolExecutor(max_workers=n) as ex:
-        futures = [ex.submit(_run_one, e, ts, seed, not args.no_synth) for e in args.extensions]
+        futures = [ex.submit(_run_one, e, ts, seed, not args.no_synth, args.prebuilt_stress)
+                   for e in args.extensions]
         outcomes = [f.result() for f in futures]   # _run_one never raises; (None, sweep_path) on failure
 
     # Ship the profiler into every claimed sweep, best-effort — _run_one returns

--- a/examples/riscv_extensions/nodes.py
+++ b/examples/riscv_extensions/nodes.py
@@ -10,6 +10,7 @@ build share one container exclusively.
 import hashlib
 import os
 import subprocess
+import tarfile
 import uuid
 
 from chia.base.ChiaFunction import ChiaFunction
@@ -211,6 +212,29 @@ def gen_to_pool(spec: GenSpec, isa: str, pool_dir: str, work_dir: str,
         unique = f"{os.path.splitext(name)[0]}_{uuid.uuid4().hex[:8]}"
         get(db_node.pool_add.chia_remote(pool_dir, unique, elf, asm, spec.instr_cnt or 0, extension=extension))
     return len(tests)
+
+
+@ChiaFunction(resources={"head_local": 0.1})
+def load_prebuilt_to_pool(ext_name: str, pool_dir: str, extension: str = "") -> int:
+    """Seed the pool from prebuilt_stress/<ext>.tar.gz (no Xcelium). The
+    --prebuilt-stress counterpart to gen_to_pool. Returns the count added."""
+    if extension: get_profiler().add_info({"extension": extension})
+    from chia.base.ChiaFunction import get
+    import riscv_extensions.db_node as db_node
+    arch = os.path.join(_VEXT_BASE, "prebuilt_stress", f"{ext_name}.tar.gz")
+    if not os.path.isfile(arch):
+        return 0
+    n = 0
+    with tarfile.open(arch, "r:gz") as tar:
+        for m in sorted(tar.getmembers(), key=lambda m: m.name):
+            if not m.isfile():
+                continue
+            elf = tar.extractfile(m).read()
+            name = "prebuilt_" + os.path.splitext(os.path.basename(m.name))[0]
+            # instr=0: untracked count -> cosim uses the default STRESS_TEST_MAX_CYCLES budget
+            get(db_node.pool_add.chia_remote(pool_dir, name, elf, "", 0, extension=extension))
+            n += 1
+    return n
 
 
 @ChiaFunction(resources={"verilator_run": COSIM_VRUN}, num_cpus=VERILATOR_THREADS)

--- a/examples/riscv_extensions/single_loop.py
+++ b/examples/riscv_extensions/single_loop.py
@@ -90,6 +90,7 @@ from riscv_extensions.nodes import (
     collect_diff,
     cosim_run,
     gen_to_pool,
+    load_prebuilt_to_pool,
     reset_chipyard,
     verilator_run_remote,
 )
@@ -441,15 +442,12 @@ def _directed_loop(llm, first_message, *, label, ext_name,
 # Stress_test phase (S3) — gen (xlm) -> cosim, producer/consumer
 # ---------------------------------------------------------------------------
 
-def _stress_test(artifact, gen_refs, pool_dir, deadline, fail_dir, archive_dir=None):
-    """Stream the test pool through the cosims (half the cluster's slots), marking each test
-    pending -> passed, until the whole batch has passed (generators in gen_refs
-    keep filling the pool in the background) or the first divergence. Returns
-    (failing CosimResult | None, cosims completed, batch complete?). When
-    generation finishes, packs every .S into one durable tarball under
-    archive_dir (once)."""
+def _stress_test(artifact, gen_refs, pool_dir, deadline, fail_dir, archive_dir=None, total=None):
+    """Stream the pool through the cosims until the batch passes or the first
+    divergence. Returns (failing CosimResult | None, cosims done, batch complete?);
+    archives the .S once generation finishes. `total` sizes the progress logs."""
     inflight, n_done, seen, archived = {}, 0, set(), False
-    total = len(gen_refs)
+    total = len(gen_refs) if total is None else total
     while time.time() < deadline:
         state = get(db_node.pool_state.chia_remote(pool_dir, extension=getattr(_ctx, "extension", "")))
         for name in sorted(state.keys() - seen):      # log tests as generators add them
@@ -602,7 +600,7 @@ def _log_ppa(run_id, base, comp):
 
 def run_vext_loop(extension: Extension, run_id: str, work_root: str,
                   seed_diff: str | None = None, archive_dir: str | None = None,
-                  synth: bool = True) -> VextResult:
+                  synth: bool = True, prebuilt: bool = False) -> VextResult:
     """One end-to-end loop implementing + proving `extension` on MegaBOOM.
     `seed_diff` (a prior run's probe diff) is applied after the reset so the
     pipeline can resume from a known implementation; if it already passes
@@ -667,10 +665,21 @@ def run_vext_loop(extension: Extension, run_id: str, work_root: str,
         # the xcelium seats pace the tasks; each registers itself in the pool
         # (scratch under DB_ROOT/tmp/, finalized+deleted by the caller).
         pool_dir = db_node.pool_path(run_id)
-        gen_isa = f"rv64gc{extension.isa_suffix}"
-        gen_refs = [gen_to_pool.chia_remote(spec, gen_isa, pool_dir, GEN_WORK_DIR, extension.dv_target, extension=extension.name)
-                    for n, spec in STRESS_TEST_MIX for _ in range(n)]
-        print(f"[{run_id}] dispatched {len(gen_refs)} generators -> pool {pool_dir}")
+        if prebuilt:
+            gen_refs = []
+            n_stress = get(load_prebuilt_to_pool.chia_remote(extension.name, pool_dir,
+                                                             extension=extension.name))
+            print(f"[{run_id}] --prebuilt-stress: loaded {n_stress} prebuilt tests -> pool {pool_dir} (skipping generation)")
+            if n_stress == 0:
+                print(f"[{run_id}] FATAL: no prebuilt binaries for {extension.name} "
+                      f"(prebuilt_stress/{extension.name}.tar.gz)")
+                return VextResult(extension.name, False, 0, 0, 0)
+        else:
+            gen_isa = f"rv64gc{extension.isa_suffix}"
+            gen_refs = [gen_to_pool.chia_remote(spec, gen_isa, pool_dir, GEN_WORK_DIR, extension.dv_target, extension=extension.name)
+                        for n, spec in STRESS_TEST_MIX for _ in range(n)]
+            n_stress = len(gen_refs)
+            print(f"[{run_id}] dispatched {n_stress} generators -> pool {pool_dir}")
         print(f"[{run_id}] resetting BOOM + fetching tests")
         get(reset_chipyard.options(**pg_opts).chia_remote(extension=extension.name))
         isa_march = f"rv64imafd_zicsr_zifencei{extension.isa_suffix}"
@@ -752,11 +761,11 @@ def run_vext_loop(extension: Extension, run_id: str, work_root: str,
         debug_llm, dbg_round = _llm("debug.md"), 0
         while True:
             _event("section_start", name="stress_test", round=dbg_round)
-            print(f"[{run_id}] stress_test round {dbg_round}: {len(gen_refs)}-test mix, "
+            print(f"[{run_id}] stress_test round {dbg_round}: {n_stress}-test mix, "
                   "half the cluster's cosim slots")
             fail, n_cosims, complete = _stress_test(artifact, gen_refs, pool_dir,
                                              time.time() + STRESS_TEST_HOURS * 3600, fail_dir,
-                                             archive_dir=archive_dir)
+                                             archive_dir=archive_dir, total=n_stress)
             _event("section_end", name="stress_test", round=dbg_round, clean=fail is None,
                    cosims=n_cosims, complete=complete)
             if fail is None:
@@ -862,6 +871,9 @@ def _parse_args():
                    help="probe diff from a prior run to seed BOOM with (resume)")
     p.add_argument("--no-synth", action="store_true",
                    help="skip sky130 PPA synthesis (run on a cluster with no synth node)")
+    p.add_argument("--prebuilt-stress", action="store_true",
+                   help="seed the stress pool from committed prebuilt binaries instead of "
+                        "generating with riscv-dv (run on a cluster with no Xcelium license)")
     return p.parse_args()
 
 
@@ -882,7 +894,8 @@ def main() -> int:
     sweep_n, sweep_path = get(db_node.claim_sweep.chia_remote(args.extension))
     get(db_node.archive_dir.chia_remote(sweep_path, "src", _tar_dir(_VEXT_DIR), extension=args.extension))
     result = run_vext_loop(EXTENSIONS[args.extension], run_id, work_root,
-                           seed_diff=seed, archive_dir=sweep_path, synth=not args.no_synth)
+                           seed_diff=seed, archive_dir=sweep_path, synth=not args.no_synth,
+                           prebuilt=args.prebuilt_stress)
     get(db_node.pool_finalize.chia_remote(db_node.pool_path(run_id), extension=args.extension))   # .S already in the sweep
     get(db_node.archive_dir.chia_remote(sweep_path, "profiler", _tar_dir(os.path.join(work_root, "profiler")), extension=args.extension))
     get(db_node.write_text.chia_remote(sweep_path, "summary.md", _render_summary(result, sweep_n), extension=args.extension))


### PR DESCRIPTION
…se without needing to run test generation which requires specific licenses