### PR TITLE
Cluster cli improvements

### DIFF
--- a/chia/cli/job.py
+++ b/chia/cli/job.py
@@ -1,9 +1,42 @@
-"""``chia job`` commands — stop (optionally killing tracked subprocesses) plus thin pass-throughs to ``ray job``."""
+"""``chia job stop`` — chia's augmented override of ``ray job stop`` (optionally
+killing tracked subprocesses first). Every other ``chia job <cmd>`` proxies to
+``ray job <cmd>`` (see chia/cli/main.py)."""
 
 from __future__ import annotations
 
+import argparse
+import os
 import subprocess
 import sys
+
+
+def run_job_stop(stop_argv, cluster=None) -> None:
+    """Parse the args after ``chia job stop`` and run the augmented stop.
+
+    This is the override entrypoint dispatched from ``main()``; it owns its own
+    argument parsing (so ``chia job stop --help`` shows chia's flags, not ray's)
+    and, if *cluster* is given, pins ``RAY_ADDRESS`` so both the ``ray.init``
+    below and the ``ray job stop`` subprocess target that cluster.
+    """
+    parser = argparse.ArgumentParser(
+        prog="chia job stop",
+        description="Stop a Ray job (optionally kill tracked subprocesses first)")
+    parser.add_argument("job_id", help="Ray job ID to stop")
+    parser.add_argument(
+        "--kill-tracked-pids", action="store_true",
+        help="Kill tracked subprocesses (via the PID registry) before stopping the job")
+    parser.add_argument(
+        "--grace-period", type=int, default=25,
+        help="Seconds to wait for each tracked subprocess to exit after SIGTERM "
+             "before escalating to SIGKILL (only used with --kill-tracked-pids; "
+             "default: 25)")
+    args = parser.parse_args(stop_argv)
+
+    if cluster is not None:
+        from chia.cli.ray_passthrough import resolve_cluster_address
+        os.environ["RAY_ADDRESS"] = resolve_cluster_address(cluster)
+
+    cmd_job_stop(args)
 
 
 def cmd_job_stop(args) -> None:
@@ -45,10 +78,4 @@ def cmd_job_stop(args) -> None:
     job_id = args.job_id
     print(f"Running: ray job stop {job_id}")
     result = subprocess.run(["ray", "job", "stop", job_id])
-    sys.exit(result.returncode)
-
-
-def cmd_job_passthrough(job_command: str, ray_args: list[str]) -> None:
-    """Forward ``chia job <cmd> ...`` verbatim to ``ray job <cmd> ...``."""
-    result = subprocess.run(["ray", "job", job_command, *ray_args])
     sys.exit(result.returncode)

--- a/chia/cli/main.py
+++ b/chia/cli/main.py
@@ -2,18 +2,94 @@ import argparse
 import sys
 
 
-# `ray job` subcommands wrapped as verbatim pass-throughs (`stop` is custom).
-RAY_JOB_PASSTHROUGH_COMMANDS = ("submit", "status", "logs", "list", "delete")
+PROMOTED_RAY_COMMANDS = ("status", "list", "job")
+
+def _extract_cluster_opt(ray_argv):
+    """Pull the chia-level ``--chia-cluster`` option out of *ray_argv*, wherever
+    it appears — so both ``chia job --chia-cluster=X status`` and ``chia job
+    status --chia-cluster=X`` work.
+
+    Scanning stops at a ``--`` separator: everything from ``--`` onward belongs
+    to a forwarded entrypoint (e.g. ``chia ray job submit -- python app.py
+    --chia-cluster foo``) and is passed through verbatim.
+
+    To specify chia cluster in the above case, use chia ray job submit --chia-cluster foo
+     -- python app.py
+
+    Returns ``(cluster_path_or_None, remaining_ray_argv)``.
+    """
+    cluster = None
+    rest = []
+    i = 0
+    while i < len(ray_argv):
+        a = ray_argv[i]
+        if a == "--":
+            rest.extend(ray_argv[i:])  # separator + entrypoint args, verbatim
+            break
+        if a == "--chia-cluster":
+            if i + 1 >= len(ray_argv):
+                sys.exit("chia: --chia-cluster requires a path argument")
+            cluster = ray_argv[i + 1]
+            i += 2
+        elif a.startswith("--chia-cluster="):
+            cluster = a[len("--chia-cluster="):]
+            i += 1
+        else:
+            rest.append(a)
+            i += 1
+    return cluster, rest
+
+
+def _find_override(ray_argv):
+    """Return ``(handler, sub_argv)`` if chia overrides this command path with
+    its own implementation instead of proxying to ray, else ``(None, None)``.
+
+    Overrides are matched on the longest command-path prefix, so ``job stop``
+    can be chia-native while ``job submit`` falls through to ray.
+    """
+    from chia.cli.job import run_job_stop
+
+    overrides = {
+        ("job", "stop"): run_job_stop,
+    }
+    for depth in (2, 1):
+        handler = overrides.get(tuple(ray_argv[:depth]))
+        if handler is not None:
+            return handler, ray_argv[depth:]
+    return None, None
+
+
+def _dispatch_ray(ray_argv, cluster, *, apply_overrides):
+    """Run *ray_argv* as a ray command, pinned to *cluster* if given.
+
+    With *apply_overrides*, a chia-native override (e.g. ``job stop``) handles
+    the command instead of proxying; ``chia ray ...`` sets this False to get
+    ray's exact behaviour.
+    """
+    if apply_overrides:
+        handler, sub_argv = _find_override(ray_argv)
+        if handler is not None:
+            handler(sub_argv, cluster)
+            return
+    from chia.cli.ray_passthrough import cmd_ray_passthrough
+    cmd_ray_passthrough(ray_argv, cluster=cluster)
 
 
 def main():
-    # Dispatch pass-throughs before argparse: REMAINDER can't capture a leading
-    # option-like token (e.g. `chia job submit --working-dir ...`), and this
-    # also forwards `--help` to ray's own, complete help text.
     argv = sys.argv[1:]
-    if len(argv) >= 2 and argv[0] == "job" and argv[1] in RAY_JOB_PASSTHROUGH_COMMANDS:
-        from chia.cli.job import cmd_job_passthrough
-        cmd_job_passthrough(argv[1], argv[2:])
+
+    # `chia ray ...` — raw ray gateway: forward everything after `ray` to the
+    # ray CLI verbatim, no chia overrides.
+    if argv and argv[0] == "ray":
+        cluster, ray_argv = _extract_cluster_opt(argv[1:])
+        _dispatch_ray(ray_argv, cluster, apply_overrides=False)
+        return
+
+    # Promoted ray commands (`chia status/list/job ...`): proxy to ray, but let
+    # chia override specific paths like `job stop`
+    if argv and argv[0] in PROMOTED_RAY_COMMANDS:
+        cluster, ray_argv = _extract_cluster_opt(argv)
+        _dispatch_ray(ray_argv, cluster, apply_overrides=True)
         return
 
     parser = argparse.ArgumentParser(
@@ -116,26 +192,17 @@ def main():
                            help="Skip confirmation prompt")
     fc_parser.add_argument("-v", "--verbose", action="store_true",
                            help="Enable verbose (DEBUG) logging")
-    # chia job stop
-    job_parser = subparsers.add_parser("job", help="Job management commands")
-    job_sub = job_parser.add_subparsers(dest="job_command")
-    job_stop_parser = job_sub.add_parser(
-        "stop", help="Stop a Ray job (optionally kill tracked subprocesses first)")
-    job_stop_parser.add_argument("job_id", help="Ray job ID to stop")
-    job_stop_parser.add_argument(
-        "--kill-tracked-pids", action="store_true",
-        help="Kill tracked subprocesses (via the PID registry) before stopping the job")
-    job_stop_parser.add_argument(
-        "--grace-period", type=int, default=25,
-        help="Seconds to wait for each tracked subprocess to exit after "
-             "SIGTERM before escalating to SIGKILL "
-             "(only used with --kill-tracked-pids; default: 25)")
-    # chia job submit/status/logs/list/delete — registered here only so they
-    # show up in `chia job --help`; real invocations are dispatched verbatim
-    # to `ray job` before argparse runs (see top of main()).
-    for name in RAY_JOB_PASSTHROUGH_COMMANDS:
-        job_sub.add_parser(name, add_help=False,
-                           help=f"Pass-through to `ray job {name}`")
+
+    _RAY_BACKED_HELP = {
+        "status": "Show cluster status (proxies to `ray status`)",
+        "list": "List cluster resources (proxies to `ray list`)",
+        "job": "Ray job commands (`stop` is chia-augmented; others proxy to `ray job`)",
+        "ray": "Run any ray command (e.g. `chia ray status`)",
+    }
+    for name, help_text in _RAY_BACKED_HELP.items():
+        help_text += "; supports --chia-cluster PATH" if name != "ray" \
+            else ", optionally pinned with --chia-cluster PATH"
+        subparsers.add_parser(name, add_help=False, help=help_text)
 
     # chia viz-profile
     viz_profile_parser = subparsers.add_parser(
@@ -169,7 +236,7 @@ def main():
         "--x-scale", type=float, default=0.5,
         help="Horizontal inches per second of wall-clock time (default: 0.5)")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.command == "up":
         from chia.cli.up import cmd_up
@@ -192,13 +259,6 @@ def main():
     elif args.command == "firesim-cleanup":
         from chia.cli.firesim_cmds import cmd_firesim_cleanup
         cmd_firesim_cleanup(args)
-    elif args.command == "job":
-        if args.job_command == "stop":
-            from chia.cli.job import cmd_job_stop
-            cmd_job_stop(args)
-        else:
-            job_parser.print_help()
-            sys.exit(1)
     elif args.command == "viz-profile":
         from chia.cli.viz_profile_cmd import cmd_viz_profile
         cmd_viz_profile(args)

--- a/chia/cli/ray_passthrough.py
+++ b/chia/cli/ray_passthrough.py
@@ -1,0 +1,58 @@
+"""``chia ray ...`` — forward a command verbatim to the ``ray`` CLI.
+
+``chia ray <args...>`` runs ``ray <args...>``, so every current and future
+``ray`` command (and its ``--help``) works through ``chia`` without being
+enumerated here.  Using an explicit ``ray`` gateway — rather than an implicit
+fallback on unknown commands — keeps chia's own ``up``/``down`` from shadowing
+``ray up``/``ray down``, and keeps ``ray``'s full help reachable.
+
+An optional chia-level ``--chia-cluster path/to/cluster.yaml`` — accepted
+either before or after the ray command — pins ``RAY_ADDRESS`` to that cluster's
+head GCS address (``head_ip:port``, parsed from the YAML).  On a host running
+more than one cluster this is what lets ``chia ray status --chia-cluster
+b.yaml`` target cluster *b* instead of whichever Ray instance ``ray``'s own
+auto-discovery would pick.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def resolve_cluster_address(cluster_path: str) -> str:
+    """Parse *cluster_path* and return its head GCS address (``head_ip:port``)."""
+    from chia.cluster.config import build_config, load_raw_config
+
+    config = build_config(load_raw_config(cluster_path))
+    return config.head_ray_address
+
+
+def cmd_ray_passthrough(ray_argv: list[str], cluster: str | None = None) -> None:
+    """Exec ``ray <ray_argv>``; if *cluster* is given, pin ``RAY_ADDRESS`` first.
+
+    Whether the command is valid is Ray's concern, not chia's: an unknown
+    command makes ``ray`` print its own error and usage and exit non-zero, and
+    that exit code is propagated here.  The only failure chia explains itself is
+    ``ray`` not being on PATH — that is the case where pointing at ``chia
+    --help`` (maybe a chia-native command was meant) is actually useful.
+    """
+    env = os.environ.copy()
+    if cluster is not None:
+        try:
+            env["RAY_ADDRESS"] = resolve_cluster_address(cluster)
+        except Exception as e:
+            sys.exit(f"chia: could not resolve --chia-cluster {cluster!r}: {e}")
+
+    # stderr so it never contaminates the forwarded command's stdout (pipes/JSON).
+    print(f"Chia: forwarding to Ray's CLI\n", file=sys.stderr)
+    if ("--help" in ray_argv) or ("-h" in ray_argv):
+        print(f"Chia Ray passthrough options:\n  --chia-cluster  None   Path to a chia cluster yaml file\n")
+    try:
+        result = subprocess.run(["ray", *ray_argv], env=env)
+    except FileNotFoundError:
+        print("chia: 'ray' was not found on PATH — is Ray installed in this "
+              "environment?", file=sys.stderr)
+        sys.exit(127)
+    sys.exit(result.returncode)

--- a/chia/cluster/config.py
+++ b/chia/cluster/config.py
@@ -148,6 +148,24 @@ class ClusterConfig:
             return override.tunnel
         return None
 
+    @property
+    def head_gcs_port(self) -> int:
+        """GCS port of the head node.
+
+        Parsed from the ``--port`` flag in ``head_start_ray_commands``.
+        Falls back to Ray's default (6379) if the flag is absent.
+        """
+        for cmd in self.head_start_ray_commands:
+            m = re.search(r"--port[=\s]+(\d+)", cmd)
+            if m:
+                return int(m.group(1))
+        return 6379
+
+    @property
+    def head_ray_address(self) -> str:
+        """Explicit GCS address (``head_ip:port``) for ``ray.init``/``--address``."""
+        return f"{self.head_ip}:{self.head_gcs_port}"
+
 
 @dataclass
 class NodeAssignment:

--- a/chia/cluster/node_setup.py
+++ b/chia/cluster/node_setup.py
@@ -91,7 +91,7 @@ def query_ray_cluster_nodes(config: ClusterConfig) -> list[dict] | None:
     query_script = list(config.head_env_commands) + [
         "python3 << 'CHIA_QUERY_EOF'",
         "import ray, json",
-        "ray.init(address='auto', ignore_reinit_error=True)",
+        f"ray.init(address='{config.head_ray_address}', ignore_reinit_error=True)",
         "nodes = [{'NodeName': n['NodeName'], 'Alive': n['Alive'], 'Resources': n.get('Resources', {})} for n in ray.nodes()]",
         "print('CHIA_NODES:' + json.dumps(nodes))",
         "CHIA_QUERY_EOF",

--- a/chia/cluster/test/multi_cluster/cluster_a.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_a.yaml
@@ -13,7 +13,7 @@ provider:
 
 auth:
     ssh_user: ${USER}
-    ssh_private_key: /home/eecs/${USER}/.ssh/${USER}
+    ssh_private_key: ${HOME}/.ssh/${USER}
 
 head_env_commands: ["source ~/.bashrc && conda activate chia_env"]
 head_setup_commands: []

--- a/chia/cluster/test/multi_cluster/cluster_a.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_a.yaml
@@ -1,0 +1,28 @@
+cluster_name: cluster_a
+
+available_node_types:
+    worker:
+        resources: {"generic": 1}
+        min_workers: 1
+        max_workers: 1
+        worker_setup_commands: ["source ~/.bashrc && conda activate chia_env"]
+        compatible_ips: ["${THIS_MACHINE}"]
+
+provider:
+    type: local
+    head_ip: ${THIS_MACHINE}
+
+auth:
+    ssh_user: ${USER}
+    ssh_private_key: /home/eecs/${USER}/.ssh/${USER}
+
+head_env_commands: ["source ~/.bashrc && conda activate chia_env"]
+head_setup_commands: []
+
+head_start_ray_commands:
+    - ray stop
+    - ulimit -c unlimited && ray start --head --port=6379 --dashboard-port=8081 --include-dashboard=True --dashboard-agent-listen-port=0 --temp-dir=/tmp/${USER}/generic
+
+worker_start_ray_commands:
+    - ray stop
+    - ray start --address=$RAY_HEAD_IP:6379 --temp-dir=/tmp/${USER}/generic

--- a/chia/cluster/test/multi_cluster/cluster_a.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_a.yaml
@@ -9,7 +9,6 @@ available_node_types:
         compatible_ips: ["${THIS_MACHINE}"]
 
 provider:
-    type: local
     head_ip: ${THIS_MACHINE}
 
 auth:

--- a/chia/cluster/test/multi_cluster/cluster_b.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_b.yaml
@@ -5,7 +5,7 @@ provider:
 
 auth:
     ssh_user: ${USER}
-    ssh_private_key: /home/eecs/${USER}/.ssh/${USER}
+    ssh_private_key: ${HOME}/.ssh/${USER}
 
 head_env_commands: ["source ~/.bashrc && conda activate chia_env"]
 head_setup_commands: []

--- a/chia/cluster/test/multi_cluster/cluster_b.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_b.yaml
@@ -1,7 +1,6 @@
 cluster_name: cluster_b
 
 provider:
-    type: local
     head_ip: ${THIS_MACHINE}
 
 auth:

--- a/chia/cluster/test/multi_cluster/cluster_b.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_b.yaml
@@ -1,0 +1,18 @@
+cluster_name: cluster_b
+
+provider:
+    type: local
+    head_ip: ${THIS_MACHINE}
+
+auth:
+    ssh_user: ${USER}
+    ssh_private_key: /home/eecs/${USER}/.ssh/${USER}
+
+head_env_commands: ["source ~/.bashrc && conda activate chia_env"]
+head_setup_commands: []
+
+head_start_ray_commands:
+    - ulimit -c unlimited && ray start --head --port=6378 --dashboard-port=8265 --include-dashboard=True --dashboard-agent-listen-port=0 --temp-dir=/tmp/${USER}/generic
+
+worker_start_ray_commands:
+    - ray start --address=$RAY_HEAD_IP:6378 --temp-dir=/tmp/${USER}/generic

--- a/chia/cluster/test/multi_cluster/cluster_b_add.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_b_add.yaml
@@ -13,7 +13,7 @@ provider:
 
 auth:
     ssh_user: ${USER}
-    ssh_private_key: /home/eecs/${USER}/.ssh/${USER}
+    ssh_private_key: ${HOME}/.ssh/${USER}
 
 head_env_commands: ["source ~/.bashrc && conda activate chia_env"]
 head_setup_commands: []

--- a/chia/cluster/test/multi_cluster/cluster_b_add.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_b_add.yaml
@@ -1,0 +1,26 @@
+cluster_name: cluster_b
+
+available_node_types:
+    worker:
+        resources: {"generic": 1}
+        min_workers: 1
+        max_workers: 1
+        worker_setup_commands: ["source ~/.bashrc && conda activate chia_env"]
+        compatible_ips: ["${THIS_MACHINE}"]
+
+provider:
+    type: local
+    head_ip: ${THIS_MACHINE}
+
+auth:
+    ssh_user: ${USER}
+    ssh_private_key: /home/eecs/${USER}/.ssh/${USER}
+
+head_env_commands: ["source ~/.bashrc && conda activate chia_env"]
+head_setup_commands: []
+
+head_start_ray_commands:
+    - ulimit -c unlimited && ray start --head --port=6378 --dashboard-port=8265 --include-dashboard=True --dashboard-agent-listen-port=0 --temp-dir=/tmp/${USER}/generic
+
+worker_start_ray_commands:
+    - ray start --address=$RAY_HEAD_IP:6378 --temp-dir=/tmp/${USER}/generic

--- a/chia/cluster/test/multi_cluster/cluster_b_add.yaml
+++ b/chia/cluster/test/multi_cluster/cluster_b_add.yaml
@@ -9,7 +9,6 @@ available_node_types:
         compatible_ips: ["${THIS_MACHINE}"]
 
 provider:
-    type: local
     head_ip: ${THIS_MACHINE}
 
 auth:

--- a/chia/cluster/test/multi_cluster/test_multi_cluster_add.py
+++ b/chia/cluster/test/multi_cluster/test_multi_cluster_add.py
@@ -1,0 +1,136 @@
+"""End-to-end worker-detection tests for ``chia up --add`` on a host that
+runs *two* Ray clusters at once.
+
+The scenario is the aliasing trap: ``cluster_a`` (head on port 6379) and
+``cluster_b`` (head on port 6378) run on the same machine and deliberately
+share one ``--temp-dir`` (``/tmp/$USER/cluster_a``).  Because they share the
+temp-dir, ``ray.init(address="auto")`` cannot tell them apart — it connects to
+whichever GCS started *last*.  ``chia up`` avoids that by addressing the head
+explicitly as ``head_ip:port`` (``ClusterConfig.head_ray_address``), parsed
+from the YAML's ``--port`` flag.
+
+Tests: 
+  * ``test_add_*`` — bring up both clusters, then:
+      - ``chia up --add cluster_b_add.yaml`` must detect the one missing
+        worker by querying cluster_b (6378).
+      - ``chia up --add cluster_a.yaml`` must report nothing to add, because
+        cluster_a (6379) already has its worker.
+
+The integration tests bring clusters up and tear them down with a host-wide
+``ray stop``, which would kill any other Ray instance on the machine.  They
+are therefore gated behind ``CHIA_RUN_MULTI_CLUSTER_TESTS=1``::
+
+    THIS_MACHINE=$(hostname -I | awk '{print $1}') \
+    CHIA_RUN_MULTI_CLUSTER_TESTS=1 \
+    python -m pytest test_multi_cluster_add.py -v -s
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import socket
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from chia.cli.up import cmd_up
+
+HERE = Path(__file__).parent
+CLUSTER_A = str(HERE / "cluster_a.yaml")
+CLUSTER_B = str(HERE / "cluster_b.yaml")
+CLUSTER_B_ADD = str(HERE / "cluster_b_add.yaml")
+
+_RUN_INTEGRATION = os.environ.get("CHIA_RUN_MULTI_CLUSTER_TESTS") == "1"
+_integration = pytest.mark.skipif(
+    not _RUN_INTEGRATION,
+    reason="set CHIA_RUN_MULTI_CLUSTER_TESTS=1 to run (brings up/tears down "
+           "real local Ray clusters; teardown runs a host-wide `ray stop`)",
+)
+
+
+def _this_machine() -> str:
+    """Primary host IP, matching the docs' ``hostname -I | awk '{print $1}'``."""
+    out = subprocess.run(["hostname", "-I"], capture_output=True, text=True)
+    parts = out.stdout.split()
+    return parts[0] if parts else socket.gethostbyname(socket.gethostname())
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _this_machine_env():
+    """The YAMLs interpolate ${THIS_MACHINE}; make sure it is set."""
+    prev = os.environ.get("THIS_MACHINE")
+    if not prev:
+        os.environ["THIS_MACHINE"] = _this_machine()
+    yield
+    if prev is None:
+        os.environ.pop("THIS_MACHINE", None)
+    else:
+        os.environ["THIS_MACHINE"] = prev
+
+
+def _args(config_file: str, *, add: bool = False, dry_run: bool = False):
+    return argparse.Namespace(
+        config_file=config_file, yes=True, verbose=False,
+        dry_run=dry_run, add=add,
+    )
+
+
+def _run_up(config_file: str, *, add: bool = False, dry_run: bool = False):
+    cmd_up(_args(config_file, add=add, dry_run=dry_run))
+
+
+def _ray_stop():
+    subprocess.run(["ray", "stop", "--force"], capture_output=True)
+
+
+def _added_count(capsys, config_file: str) -> int:
+    """Run ``chia up --add <config> --dry-run`` and return the planned add count.
+
+    ``--dry-run`` performs the real cluster query + assignment diff and prints
+    the plan, then returns without mutating anything.
+    """
+    _run_up(config_file, add=True, dry_run=True)
+    out = capsys.readouterr().out
+    m = re.search(r"Will add (\d+) new worker", out)
+    assert m is not None, f"add-plan line not found in output:\n{out}"
+    return int(m.group(1))
+
+# ---------------------------------------------------------------------------
+# Integration tests — bring up both clusters, then exercise --add detection.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def clusters_up(_this_machine_env):
+    try:
+        _run_up(CLUSTER_A)   # head :6379 + worker (worker_a)
+        _run_up(CLUSTER_B)   # head :6378, no workers
+    except SystemExit as e:
+        _ray_stop()
+        pytest.skip(
+            f"chia up exited with {e.code}; integration test needs "
+            "SSH-to-localhost, the chia_env conda env, and ray on PATH")
+    except Exception as e:  # pragma: no cover - environment-dependent
+        _ray_stop()
+        pytest.skip(f"could not bring up local clusters: {e!r}")
+    yield
+    _ray_stop()
+
+
+@_integration
+def test_add_detects_missing_worker_on_correct_cluster(clusters_up, capsys):
+    # cluster_b has no workers; cluster_b_add wants one "generic" worker. The
+    # query must hit cluster_b (:6378), not the temp-dir-sharing cluster_a
+    # (:6379, which DOES have a "generic" worker), and report one to add.
+    assert _added_count(capsys, CLUSTER_B_ADD) == 1
+
+
+@_integration
+def test_add_reports_nothing_when_worker_present(clusters_up, capsys):
+    # cluster_a already has its "generic" worker. Querying the right cluster
+    # (:6379) reports zero to add. With address="auto" this resolves to the
+    # last-started cluster (cluster_b, :6378), which has no worker, and wrongly
+    # reports one to add — the aliasing bug this suite guards against.
+    assert _added_count(capsys, CLUSTER_A) == 0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Originally CHIA stood for:
    :maxdepth: 2
    :caption: User Guides
 
+   user_guides/reference
    user_guides/chia_function
    user_guides/chia_tool
    user_guides/cluster_config_reference
@@ -61,12 +62,6 @@ Originally CHIA stood for:
    case-studies/timing-optimization
    case-studies/architectural-discovery-basic
    case-studies/circt-issue-solving
-
-.. toctree::
-   :maxdepth: 2
-   :caption: CLI Reference
-
-   cli/reference
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user_guides/reference.rst
+++ b/docs/user_guides/reference.rst
@@ -2,7 +2,7 @@ CLI Reference
 =============
 
 The ``chia`` console script (``chia/cli/main.py``) manages clusters, visualizes
-flows, and wraps Ray job management.
+flows, and proxies Ray's CLI (with optional per-cluster targeting).
 
 .. code-block:: text
 
@@ -83,12 +83,66 @@ Visualize a ``ChiaProfileCollector`` JSONL log. See the
    * - ``--x-scale F``
      - Horizontal inches per second of wall-clock (default 0.5).
 
-Jobs
-----
+Cluster Status
+----------------
 
-``chia job <subcommand>`` — ``submit``, ``status``, ``logs``, ``list``, and ``delete`` are
-**pass-throughs** to ``ray job`` (so ``--help`` shows Ray's own help). ``stop`` is
-custom:
+``chia status [...]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Print cluster status. Proxies to ``ray status``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Flag
+     - Meaning
+   * - ``--chia-cluster {path/to/cluster.yaml}``
+     - Specify the Chia cluster YAML file to target.
+   * - ``...``
+     - all other args (including ``--help``) go to Ray.
+
+
+``chia list [...]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+List all states of a given resource. Proxies to ``ray list`` (e.g. ``chia list nodes``).
+
+.. list-table::
+   :header-rows: 1
+
+   * - Flag
+     - Meaning
+   * - ``--chia-cluster {path/to/cluster.yaml}``
+     - Specify the Chia cluster YAML file to target.
+   * - ``...``
+     - all other args (including ``--help``) go to Ray.
+
+Job Management
+------------------
+
+``chia job <subcommand> [...]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Submit, stop, delete, or list Ray jobs.
+
+Proxies to ``ray job`` — ``submit``, ``status``, ``logs``, ``list``, ``delete``,
+etc. all forward, so ``chia job --help`` shows Ray's own job help. Supports
+``--chia-cluster``. The one exception is ``stop``, which
+chia *overrides* with an augmented implementation; use ``chia ray job stop`` for
+Ray's unmodified behavior.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Flag
+     - Meaning
+   * - ``--chia-cluster {path/to/cluster.yaml}``
+     - Specify the Chia cluster YAML file to target.
+   * - ``stop {job_id}``
+     - Stop a job by its ID.
+   * - ``...``
+     - all other args (including ``--help``) go to Ray.
+
 
 ``chia job stop <job_id>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -110,6 +164,26 @@ completes in well under the grace period.
    * - ``--grace-period SEC``
      - Seconds to wait for each tracked subprocess to exit after SIGTERM before
        escalating to SIGKILL (only used with ``--kill-tracked-pids``; default 25).
+
+.. _cli-ray-fallback:
+
+Fallback to Ray (``chia ray ...``)
+----------------------------------
+
+``chia ray <anything>`` forwards to ``ray <anything>`` verbatim, so every
+current and future Ray command (``ray memory``, ``ray timeline``, ``ray
+attach`` …) is reachable — not just the promoted ``status``/``list``/``job``.
+Using an explicit gateway also means chia's own ``up``/``down`` never shadow
+``ray up``/``ray down``, and ``chia ray --help`` shows Ray's complete command
+list.
+
+Supports ``--chia-cluster``. Unlike the promoted
+commands, the fallback applies **no** overrides — ``chia ray job stop`` runs
+Ray's stop, not chia's augmented one::
+
+   chia ray memory --chia-cluster=cluster_a.yaml
+   chia ray timeline
+   chia ray job stop <job_id>
 
 FireSim
 -------


### PR DESCRIPTION
CLI updates:
---------------

- add chia support for chia status, chia list, and chia job
  - these wrap around the ray equivalent
  - chia-specific ray job stop still supported
  -  add --chia-cluster arg for these commands (under the hood, specifies RAY_ADDRESS when calling the corresponding ray command)
- add fall-back for unsupported ray commands with ``chia ray ...``
  - also support --chia-cluster arg